### PR TITLE
Create FilteredReader to read only needed lines

### DIFF
--- a/common/src/main/java/com/hartwig/healthchecks/common/io/path/PathFinder.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/io/path/PathFinder.java
@@ -1,0 +1,31 @@
+package com.hartwig.healthchecks.common.io.path;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.jetbrains.annotations.NotNull;
+
+@FunctionalInterface
+public interface PathFinder {
+
+    String FILE_S_NOT_FOUND_MSG = "File %s not Found in path %s";
+
+    @NotNull
+    Path findPath(@NotNull final String path, @NotNull String extension) throws IOException;
+
+    @NotNull
+    static PathFinder build() {
+        return (path, extension) -> {
+            final Optional<Path> searchedFile = Files.walk(new File(path).toPath())
+                            .filter(filePath -> filePath.getFileName().toString().endsWith(extension)).findFirst();
+            if (!searchedFile.isPresent()) {
+                throw new FileNotFoundException(String.format(FILE_S_NOT_FOUND_MSG, extension, path));
+            }
+            return searchedFile.get();
+        };
+    }
+}

--- a/common/src/main/java/com/hartwig/healthchecks/common/io/reader/FilteredReader.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/io/reader/FilteredReader.java
@@ -1,0 +1,39 @@
+package com.hartwig.healthchecks.common.io.reader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.hartwig.healthchecks.common.exception.HealthChecksException;
+import com.hartwig.healthchecks.common.exception.LineNotFoundException;
+import com.hartwig.healthchecks.common.io.path.PathFinder;
+
+@FunctionalInterface
+public interface FilteredReader {
+
+    String LINE_NOT_FOUND_ERROR = "File %s does not contain lines with value %s";
+
+    @NotNull
+    List<String> readLines(@NotNull final String path, @NotNull String extension, @NotNull Predicate<String> filter)
+                    throws IOException, HealthChecksException;
+
+    @NotNull
+    static FilteredReader build() {
+        return (path, extension, filter) -> {
+            final Path fileToRead = PathFinder.build().findPath(path, extension);
+            final List<String> searchedLines = Files.lines(Paths.get(fileToRead.toString())).filter(filter)
+                            .collect(Collectors.toList());
+            if (searchedLines.isEmpty()) {
+                throw new LineNotFoundException(String.format(LINE_NOT_FOUND_ERROR, extension, filter.toString()));
+            }
+            return searchedLines;
+        };
+    }
+
+}

--- a/common/src/main/java/com/hartwig/healthchecks/common/io/reader/Reader.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/io/reader/Reader.java
@@ -1,16 +1,15 @@
 package com.hartwig.healthchecks.common.io.reader;
 
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
+
+import com.hartwig.healthchecks.common.io.path.PathFinder;
 
 @FunctionalInterface
 public interface Reader {
@@ -23,14 +22,8 @@ public interface Reader {
     @NotNull
     static Reader build() {
         return (path, extension) -> {
-            final Optional<Path> searchedFile = Files.walk(new File(path).toPath())
-                    .filter(filePath -> filePath.getFileName().toString().endsWith(extension)).findFirst();
-            if (!searchedFile.isPresent()) {
-                throw new FileNotFoundException(String.format(FILE_S_NOT_FOUND_MSG, extension, path));
-            }
-            final Path fileToRead = searchedFile.get();
+            final Path fileToRead = PathFinder.build().findPath(path, extension);
             return Files.lines(Paths.get(fileToRead.toString())).collect(Collectors.toList());
         };
     }
-
 }

--- a/common/src/main/java/com/hartwig/healthchecks/common/predicate/VCFHeaderLinePredicate.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/predicate/VCFHeaderLinePredicate.java
@@ -1,0 +1,14 @@
+package com.hartwig.healthchecks.common.predicate;
+
+import java.util.function.Predicate;
+
+public class VCFHeaderLinePredicate implements Predicate<String> {
+
+    private static final String CHROM = "#CHROM";
+
+    @Override
+    public boolean test(final String line) {
+        return line.startsWith(CHROM);
+    }
+
+}

--- a/common/src/main/java/com/hartwig/healthchecks/common/predicate/VCFPassDataLinePredicate.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/predicate/VCFPassDataLinePredicate.java
@@ -1,0 +1,30 @@
+package com.hartwig.healthchecks.common.predicate;
+
+import java.util.function.Predicate;
+
+public class VCFPassDataLinePredicate implements Predicate<String> {
+
+    private static final String SEPERATOR_REGEX = "\t";
+
+    private static final int FILTER_INDEX = 6;
+
+    private static final String DOT = ".";
+
+    private static final String PASS = "PASS";
+
+    private static final String HASH = "#";
+
+    @Override
+    public boolean test(final String line) {
+        boolean isData = false;
+        if (!line.startsWith(HASH)) {
+            final String[] values = line.split(SEPERATOR_REGEX);
+            final String filterValue = values[FILTER_INDEX];
+            if (filterValue.equals(PASS) || filterValue.equals(DOT)) {
+                isData = true;
+            }
+        }
+        return isData;
+    }
+
+}

--- a/common/src/main/java/com/hartwig/healthchecks/common/util/CheckType.java
+++ b/common/src/main/java/com/hartwig/healthchecks/common/util/CheckType.java
@@ -11,5 +11,5 @@ public enum CheckType {
     SOMATIC,
     SLICED,
     REALIGNER,
-    VARIANTS;
+    GERMLINE;
 }

--- a/common/src/test/java/com/hartwig/healthchecks/common/predicate/VCFHeaderLinePredicateTest.java
+++ b/common/src/test/java/com/hartwig/healthchecks/common/predicate/VCFHeaderLinePredicateTest.java
@@ -1,0 +1,101 @@
+package com.hartwig.healthchecks.common.predicate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hartwig.healthchecks.common.predicate.VCFHeaderLinePredicate;
+
+public class VCFHeaderLinePredicateTest {
+
+    private static final String PASS_DATA_LINE = "2\t212812060\trs839540\t%s\t%s\t.\tPASS\tAC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String DOT_DATA_LINE = "2\t212812060\trs839540\t%s\t%s\t.\t.\t" + "AC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String OTHER_DATA_LINE = "2\t212812060\trs839540\tT\tC\t.\tbla\t" + "AC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String FILLING_LINE = "##FILTER=<ID=str10,Description="
+                    + "\"Less than 10% or more than 90% of variant supporting reads on one strand\">";
+
+    private static final String HEADER_LINE = "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT"
+                    + "\tCPCT12345678R\tCPCT12345678T";
+
+    private VCFHeaderLinePredicate predicate;
+
+    @Before
+    public void setUp() {
+        predicate = new VCFHeaderLinePredicate();
+    }
+
+    @Test
+    public void checkHeaderLine() {
+        assertTrue(predicate.test(HEADER_LINE));
+    }
+
+    @Test
+    public void checkPassLine() {
+        assertFalse(predicate.test(PASS_DATA_LINE));
+    }
+
+    @Test
+    public void checkDotLine() {
+        assertFalse(predicate.test(DOT_DATA_LINE));
+    }
+
+    @Test
+    public void checkHashLine() {
+        assertFalse(predicate.test(FILLING_LINE));
+    }
+
+    @Test
+    public void checkOtherLine() {
+        assertFalse(predicate.test(OTHER_DATA_LINE));
+    }
+}

--- a/common/src/test/java/com/hartwig/healthchecks/common/predicate/VCFPassDataLinePredicateTest.java
+++ b/common/src/test/java/com/hartwig/healthchecks/common/predicate/VCFPassDataLinePredicateTest.java
@@ -1,0 +1,93 @@
+package com.hartwig.healthchecks.common.predicate;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.hartwig.healthchecks.common.predicate.VCFPassDataLinePredicate;
+
+public class VCFPassDataLinePredicateTest {
+
+    private static final String PASS_DATA_LINE = "2\t212812060\trs839540\t%s\t%s\t.\tPASS\tAC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String DOT_DATA_LINE = "2\t212812060\trs839540\t%s\t%s\t.\t.\t" + "AC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String OTHER_DATA_LINE = "2\t212812060\trs839540\tT\tC\t.\tbla\t" + "AC=1;AF=0.333;AN=3;"
+                    + "ANN=C|sequence_feature|LOW|ERBB4|ENSG00000178568|topological_domain:Extracellular|"
+                    + "ENST00000342788|protein_coding||c.421+95A>G||||||,C|sequence_feature|LOW|ERBB4|ENSG00000178568|"
+                    + "topological_domain:Extracellular|ENST00000436443|protein_coding||c.421+95A>G||||||,C|"
+                    + "intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000342788|protein_coding|3/27|"
+                    + "c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000436443|"
+                    + "protein_coding|3/26|c.421+95A>G||||||,C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|"
+                    + "transcript|ENST00000402597|protein_coding|3/27|c.421+95A>G||||||,C|intron_variant|"
+                    + "MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000484594|"
+                    + "retained_intron|3/19|n.473+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000260943|protein_coding|"
+                    + "3/18|c.418+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE,C|intron_variant|MODIFIER|ERBB4|"
+                    + "ENSG00000178568|transcript|ENST00000484474|processed_transcript|2/4|n.338+95A>G||||||,"
+                    + "C|intron_variant|MODIFIER|ERBB4|ENSG00000178568|transcript|ENST00000435846|protein_coding|"
+                    + "3/4|c.244+95A>G||||||WARNING_TRANSCRIPT_INCOMPLETE;DB;SOMATIC;VT=SNP;set=mutect"
+                    + "\tGT:AD:BQ:DP:FA:SS\t./.\t0:25,0:.:25:0.00:0\t./.\t0/1:5,13:40:18:0.722:2\t./. ./. ./. ./.";
+
+    private static final String FILLING_LINE = "##FILTER=<ID=str10,Description="
+                    + "\"Less than 10% or more than 90% of variant supporting reads on one strand\">";
+
+    private VCFPassDataLinePredicate predicate;
+
+    @Before
+    public void setUp() {
+        predicate = new VCFPassDataLinePredicate();
+    }
+
+    @Test
+    public void checkPassLine() {
+        assertTrue(predicate.test(PASS_DATA_LINE));
+    }
+
+    @Test
+    public void checkDotLine() {
+        assertTrue(predicate.test(DOT_DATA_LINE));
+    }
+
+    @Test
+    public void checkHashLine() {
+        assertFalse(predicate.test(FILLING_LINE));
+    }
+
+    @Test
+    public void checkOtherLine() {
+        assertFalse(predicate.test(OTHER_DATA_LINE));
+    }
+}

--- a/nesbit/src/main/java/com/hartwig/healthchecks/nesbit/adapter/NesbitAdapter.java
+++ b/nesbit/src/main/java/com/hartwig/healthchecks/nesbit/adapter/NesbitAdapter.java
@@ -6,7 +6,7 @@ import com.hartwig.healthchecks.common.adapter.HealthCheckAdapter;
 import com.hartwig.healthchecks.common.checks.HealthChecker;
 import com.hartwig.healthchecks.common.checks.HealthCheckerImpl;
 import com.hartwig.healthchecks.common.io.extractor.DataExtractor;
-import com.hartwig.healthchecks.common.io.reader.Reader;
+import com.hartwig.healthchecks.common.io.reader.FilteredReader;
 import com.hartwig.healthchecks.common.report.JsonReport;
 import com.hartwig.healthchecks.common.report.Report;
 import com.hartwig.healthchecks.common.resource.ResourceWrapper;
@@ -14,7 +14,7 @@ import com.hartwig.healthchecks.common.util.BaseReport;
 import com.hartwig.healthchecks.common.util.CheckCategory;
 import com.hartwig.healthchecks.common.util.CheckType;
 import com.hartwig.healthchecks.nesbit.extractor.SomaticExtractor;
-import com.hartwig.healthchecks.nesbit.extractor.VariantsExtractor;
+import com.hartwig.healthchecks.nesbit.extractor.GermlineExtractor;
 
 @ResourceWrapper(type = CheckCategory.NESBIT)
 public class NesbitAdapter implements HealthCheckAdapter {
@@ -23,13 +23,13 @@ public class NesbitAdapter implements HealthCheckAdapter {
 
     @Override
     public void runCheck(@NotNull final String runDirectory) {
-        final Reader variantsReader = Reader.build();
-        final DataExtractor variantsExtractor = new VariantsExtractor(variantsReader);
-        final HealthChecker variants = new HealthCheckerImpl(CheckType.VARIANTS, runDirectory, variantsExtractor);
-        final BaseReport variantsReport = variants.runCheck();
-        report.addReportData(variantsReport);
+        final FilteredReader germlineReader = FilteredReader.build();
+        final DataExtractor germlineExtractor = new GermlineExtractor(germlineReader);
+        final HealthChecker germline = new HealthCheckerImpl(CheckType.GERMLINE, runDirectory, germlineExtractor);
+        final BaseReport germlineReport = germline.runCheck();
+        report.addReportData(germlineReport);
 
-        final Reader somaticReader = Reader.build();
+        final FilteredReader somaticReader = FilteredReader.build();
         final DataExtractor somaticExtractor = new SomaticExtractor(somaticReader);
         final HealthChecker somatic = new HealthCheckerImpl(CheckType.SOMATIC, runDirectory, somaticExtractor);
         final BaseReport somaticReport = somatic.runCheck();

--- a/nesbit/src/main/java/com/hartwig/healthchecks/nesbit/extractor/AbstractVCFExtractor.java
+++ b/nesbit/src/main/java/com/hartwig/healthchecks/nesbit/extractor/AbstractVCFExtractor.java
@@ -2,7 +2,6 @@ package com.hartwig.healthchecks.nesbit.extractor;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -15,62 +14,48 @@ import com.hartwig.healthchecks.nesbit.model.VCFType;
 
 public abstract class AbstractVCFExtractor extends AbstractDataExtractor {
 
-    protected static final String CHROM = "#CHROM";
-
     private static final int INFO_INDEX = 7;
 
     private static final int ALT_INDEX = 4;
 
     private static final int REF_INDEX = 3;
 
-    private static final int FILTER_INDEX = 6;
-
     private final String[] neededHeaders = {"FILTER", "REF", "ALT", "INFO", "(CPCT)(\\d+)(T)"};
 
     private final String[] neededHeadersVariants = {"(CPCT)(\\d+)(R)"};
 
-    protected String getHeaders(final List<String> lines, final String extension, final boolean isVariantsCheck)
+    protected String[] getHeaders(final List<String> lines, final String extension, final boolean isGermlineCheck)
                     throws LineNotFoundException, HeaderNotFoundException {
-        final Optional<String> headerLine = lines.stream().filter(line -> line.contains(CHROM)).findFirst();
-
-        if (!headerLine.isPresent()) {
-            throw new LineNotFoundException(String.format(LINE_NOT_FOUND_ERROR, extension, CHROM));
-        }
-        final String[] headers = headerLine.get().split(SEPERATOR_REGEX);
+        final String[] headers = lines.get(ZERO).split(SEPERATOR_REGEX);
 
         List<String> expecetedHeaders = Arrays.stream(neededHeaders).collect(Collectors.toList());
-        if (isVariantsCheck) {
+        if (isGermlineCheck) {
             expecetedHeaders = Stream.concat(Arrays.stream(neededHeaders), Arrays.stream(neededHeadersVariants))
                             .collect(Collectors.toList());
         }
         final List<String> validation = expecetedHeaders.stream()
                         .filter(expectedHeader -> Arrays.stream(headers)
-                                        .filter(header -> header.matches(expectedHeader)).count() < 1)
+                                        .filter(header -> header.matches(expectedHeader)).count() < ONE)
                         .collect(Collectors.toList());
         if (!validation.isEmpty()) {
             final String missingHeaders = validation.stream().map(Object::toString)
                             .collect(Collectors.joining(COMMA_DELIMITER));
             throw new HeaderNotFoundException(String.format(HEADER_NOT_FOUND_ERROR, extension, missingHeaders));
         }
-        return headerLine.get();
+        return headers;
     }
 
     protected List<VCFData> getVCFData(final List<String> lines) {
-        return lines.stream().filter(line -> !line.startsWith(HASH)).map(line -> {
+        return lines.stream().map(line -> {
             final String[] values = line.split(SEPERATOR_REGEX);
-            VCFData vcfData = null;
-            final String filterValue = values[FILTER_INDEX];
-            if (filterValue.contains(PASS) || filterValue.contains(DOT)) {
-                final String ref = values[REF_INDEX];
-                final String alt = values[ALT_INDEX];
-                final String info = values[INFO_INDEX];
-                VCFType type = VCFType.INDELS;
-                if (ref.length() == alt.length()) {
-                    type = VCFType.SNP;
-                }
-                vcfData = new VCFData(type, ref, alt, info);
+            final String ref = values[REF_INDEX];
+            final String alt = values[ALT_INDEX];
+            final String info = values[INFO_INDEX];
+            VCFType type = VCFType.INDELS;
+            if (ref.length() == alt.length()) {
+                type = VCFType.SNP;
             }
-            return vcfData;
+            return new VCFData(type, ref, alt, info);
         }).filter(vcfData -> vcfData != null).collect(Collectors.toList());
     }
 

--- a/nesbit/src/test/java/com/hartwig/healthchecks/nesbit/adapter/NesbitAdapterTest.java
+++ b/nesbit/src/test/java/com/hartwig/healthchecks/nesbit/adapter/NesbitAdapterTest.java
@@ -12,7 +12,7 @@ import com.hartwig.healthchecks.common.report.PatientMultiChecksReport;
 import com.hartwig.healthchecks.common.util.BaseReport;
 import com.hartwig.healthchecks.common.util.CheckType;
 import com.hartwig.healthchecks.nesbit.extractor.SomaticExtractor;
-import com.hartwig.healthchecks.nesbit.extractor.VariantsExtractor;
+import com.hartwig.healthchecks.nesbit.extractor.GermlineExtractor;
 
 import mockit.Mocked;
 import mockit.NonStrictExpectations;
@@ -39,7 +39,7 @@ public class NesbitAdapterTest {
                 result = report;
                 times = 1;
 
-                new HealthCheckerImpl(CheckType.VARIANTS, anyString, (VariantsExtractor) any);
+                new HealthCheckerImpl(CheckType.GERMLINE, anyString, (GermlineExtractor) any);
                 result = variant;
                 times = 1;
                 variant.runCheck();
@@ -69,7 +69,7 @@ public class NesbitAdapterTest {
 
     private BaseReport getVariantDummyReport() {
         final BaseDataReport testDataReport = new BaseDataReport(DUMMY_ID, DUMMY_CHECK, REF_VALUE);
-        return new PatientMultiChecksReport(CheckType.VARIANTS, Arrays.asList(testDataReport));
+        return new PatientMultiChecksReport(CheckType.GERMLINE, Arrays.asList(testDataReport));
     }
 
     private BaseReport getSomticDummyReport() {


### PR DESCRIPTION
some of th vcf files are big and we don't need all it is line.
This FilteredReader will use java 8 stream to read only needed lines
using pre-define predicates like VCFHeaderLinePredicate
or VCFPassDataLinePredicate.

Changes :
- Create FilteredReader
- Create different Predicates
- Rename VariantsExtractor -> GermlineExtractor
- Simplify the SomaticExtractor and GermlineExtractor
- Update and add tests